### PR TITLE
Feature to use kafka to send span

### DIFF
--- a/zipkin-core/pom.xml
+++ b/zipkin-core/pom.xml
@@ -27,9 +27,9 @@
             <version>${brave.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.kristofa</groupId>
+            <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-spancollector-kafka</artifactId>
-            <version>3.7.0</version>
+            <version>${brave.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/zipkin-core/pom.xml
+++ b/zipkin-core/pom.xml
@@ -26,5 +26,10 @@
             <artifactId>brave-spancollector-http</artifactId>
             <version>${brave.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.kristofa</groupId>
+            <artifactId>brave-spancollector-kafka</artifactId>
+            <version>3.7.0</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
1. Added two variables in Zipkin Factory: bootstrapServers, topic : both required for kafka producer.
2. Created span Collector using brave kafka span collector.

Signed-off-by: Rakesh Kumar <rakeshkumar4294@gmail.com>