### PR TITLE
update zipkin-rx support

### DIFF
--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/AbstractZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/AbstractZipkinFactory.java
@@ -148,7 +148,7 @@ public abstract class AbstractZipkinFactory implements ZipkinFactory {
 
         final Brave brave = new Brave.Builder(toInt(serviceHost), servicePort,
                 serviceName).reporter(reporter)
-                        .traceSampler(sampler)
+                        .traceSampler(getSampler())
                         .traceId128Bit(traceId128Bit).build();
 
         // Register the request filter for incoming server requests

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/AbstractZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/AbstractZipkinFactory.java
@@ -16,11 +16,11 @@
 package com.smoketurner.dropwizard.zipkin;
 
 import javax.annotation.Nonnull;
-
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.Sampler;
@@ -28,7 +28,6 @@ import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.jaxrs2.BraveContainerRequestFilter;
 import com.github.kristofa.brave.jaxrs2.BraveContainerResponseFilter;
 import com.google.common.net.InetAddresses;
-
 import io.dropwizard.setup.Environment;
 import io.dropwizard.validation.PortRange;
 import zipkin.Span;
@@ -56,7 +55,11 @@ public abstract class AbstractZipkinFactory implements ZipkinFactory {
     @PortRange
     private int servicePort = DEFAULT_DW_PORT;
 
-    private Sampler sampler;
+    @Min(0)
+    @Max(1)
+    private float sampleRate = 1.0f;
+
+    private Sampler sampler = null;
 
     private boolean traceId128Bit = false;
 
@@ -92,7 +95,20 @@ public abstract class AbstractZipkinFactory implements ZipkinFactory {
     }
 
     @JsonProperty
+    public float getSampleRate() {
+        return sampleRate;
+    }
+
+    @JsonProperty
+    public void setSampleRate(float sampleRate) {
+        this.sampleRate = sampleRate;
+    }
+
+    @JsonProperty
     public Sampler getSampler() {
+        if (sampler == null) {
+            sampler = Sampler.create(sampleRate);
+        }
         return sampler;
     }
 

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/AbstractZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/AbstractZipkinFactory.java
@@ -16,11 +16,11 @@
 package com.smoketurner.dropwizard.zipkin;
 
 import javax.annotation.Nonnull;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
+
 import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.kristofa.brave.Brave;
 import com.github.kristofa.brave.Sampler;
@@ -28,6 +28,7 @@ import com.github.kristofa.brave.http.DefaultSpanNameProvider;
 import com.github.kristofa.brave.jaxrs2.BraveContainerRequestFilter;
 import com.github.kristofa.brave.jaxrs2.BraveContainerResponseFilter;
 import com.google.common.net.InetAddresses;
+
 import io.dropwizard.setup.Environment;
 import io.dropwizard.validation.PortRange;
 import zipkin.Span;
@@ -55,9 +56,7 @@ public abstract class AbstractZipkinFactory implements ZipkinFactory {
     @PortRange
     private int servicePort = DEFAULT_DW_PORT;
 
-    @Min(0)
-    @Max(1)
-    private float sampleRate = 1.0f;
+    private Sampler sampler;
 
     private boolean traceId128Bit = false;
 
@@ -93,13 +92,13 @@ public abstract class AbstractZipkinFactory implements ZipkinFactory {
     }
 
     @JsonProperty
-    public float getSampleRate() {
-        return sampleRate;
+    public Sampler getSampler() {
+        return sampler;
     }
 
     @JsonProperty
-    public void setSampleRate(float sampleRate) {
-        this.sampleRate = sampleRate;
+    public void setSampler(Sampler sampler) {
+        this.sampler = sampler;
     }
 
     @JsonProperty
@@ -133,7 +132,7 @@ public abstract class AbstractZipkinFactory implements ZipkinFactory {
 
         final Brave brave = new Brave.Builder(toInt(serviceHost), servicePort,
                 serviceName).reporter(reporter)
-                        .traceSampler(Sampler.create(sampleRate))
+                        .traceSampler(sampler)
                         .traceId128Bit(traceId128Bit).build();
 
         // Register the request filter for incoming server requests

--- a/zipkin-example/pom.xml
+++ b/zipkin-example/pom.xml
@@ -22,6 +22,11 @@
             <artifactId>zipkin-client</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.smoketurner.dropwizard</groupId>
+            <artifactId>zipkin-rx</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/zipkin-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
+++ b/zipkin-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
@@ -21,9 +21,12 @@ import com.github.kristofa.brave.Brave;
 import com.smoketurner.dropwizard.zipkin.ZipkinBundle;
 import com.smoketurner.dropwizard.zipkin.ZipkinFactory;
 import com.smoketurner.dropwizard.zipkin.client.ZipkinClientBuilder;
+import com.smoketurner.dropwizard.zipkin.rx.BraveRxJavaSchedulersHook;
+
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import rx.plugins.RxJavaHooks;
 
 public class HelloWorldApplication
         extends Application<HelloWorldConfiguration> {
@@ -57,6 +60,9 @@ public class HelloWorldApplication
 
         final Client client = new ZipkinClientBuilder(environment, brave)
                 .build(configuration.getZipkinClient());
+
+        BraveRxJavaSchedulersHook hook = new BraveRxJavaSchedulersHook(brave);
+        RxJavaHooks.setOnScheduleAction(hook::onSchedule);
 
         // Register resources
         final HelloWorldResource resource = new HelloWorldResource(client);

--- a/zipkin-rx/pom.xml
+++ b/zipkin-rx/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/zipkin-rx/src/main/java/com/smoketurner/dropwizard/zipkin/rx/BraveRxJavaSchedulersHook.java
+++ b/zipkin-rx/src/main/java/com/smoketurner/dropwizard/zipkin/rx/BraveRxJavaSchedulersHook.java
@@ -22,10 +22,6 @@ import com.github.kristofa.brave.ServerSpanThreadBinder;
 import rx.functions.Action0;
 import rx.plugins.RxJavaSchedulersHook;
 
-/**
- * @deprecated No longer able to support
- */
-@Deprecated
 public final class BraveRxJavaSchedulersHook extends RxJavaSchedulersHook {
 
     private final Brave brave;


### PR DESCRIPTION
RxJava 1.2.x deprecated the RxJavaSchedulersHook.onSchedule() method.  This commit sets up the brave rx hook in the currently preferred manner. 