### PR TITLE
Use v2 http reporting path since this is default with version 2 of zipkin-reporter

### DIFF
--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
@@ -15,6 +15,7 @@
  */
 package com.smoketurner.dropwizard.zipkin;
 
+import java.net.URI;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -68,7 +69,7 @@ public class HttpZipkinFactory extends AbstractZipkinFactory {
                 environment.metrics());
 
         final URLConnectionSender sender = URLConnectionSender
-                .create(baseUrl + "api/v1/spans");
+                .create(URI.create(baseUrl).resolve("api/v2/spans").toString());
 
         final AsyncReporter<Span> reporter = AsyncReporter.builder(sender)
                 .metrics(metricsHandler).build();


### PR DESCRIPTION
With existing versions of this library, since zipkin-reporter update to 2.x.x, HTTP collector does not seem to send any spans to the Zipkin server.

The problem turned out to be incorrect endpoint/span encoding combination.

As per documentation of zipkin-reporter: https://github.com/openzipkin/zipkin-reporter-java#asyncreporter
V2 encoding is used by default.
In order for V1 encoding to be used and sent to `api/v1/spans` endpoint, it has to be configured explicitly:
https://github.com/openzipkin/zipkin-reporter-java#legacy-encoding

