### PR TITLE
Removes dep on io.zipkin.java by using latest Brave

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,7 @@
         <file.encoding>UTF-8</file.encoding>
         <javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
         <dropwizard.version>1.2.3</dropwizard.version>
-        <brave.version>4.14.1</brave.version>
-        <zipkin.version>2.4.5</zipkin.version>
+        <brave.version>4.14.3</brave.version>
         <zipkin.reporter.version>2.3.1</zipkin.reporter.version>
     </properties>
 

--- a/zipkin-core/pom.xml
+++ b/zipkin-core/pom.xml
@@ -27,11 +27,6 @@
             <version>${brave.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.zipkin.java</groupId>
-            <artifactId>zipkin</artifactId>
-            <version>${zipkin.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-sender-urlconnection</artifactId>
             <version>${zipkin.reporter.version}</version>

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/AbstractZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/AbstractZipkinFactory.java
@@ -214,7 +214,7 @@ public abstract class AbstractZipkinFactory implements ZipkinFactory {
 
         final Tracing tracing = Tracing.newBuilder()
                 .currentTraceContext(MDCCurrentTraceContext.create())
-                .localEndpoint(endpoint).spanReporter(reporter)
+                .endpoint(endpoint).spanReporter(reporter)
                 .sampler(getSampler()).traceId128Bit(traceId128Bit).build();
 
         final HttpTracing httpTracing = HttpTracing.newBuilder(tracing)


### PR DESCRIPTION
Latest Brave adds a renamed method which obviates a zipkin v1 dependency.