### PR TITLE
Change timeouts to be configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,11 @@ matrix:
           packages:
             - oracle-java8-installer
     - os: linux
-      jdk: openjdk10
+      jdk: oraclejdk10
+      addons:
+        apt:
+          packages:
+            - oracle-java10-installer
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,7 @@ matrix:
           packages:
             - oracle-java8-installer
     - os: linux
-      jdk: oraclejdk10
-      addons:
-        apt:
-          packages:
-            - oracle-java10-installer
+      jdk: openjdk10
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ zipkin:
   collector: http
   # If using the http collector, provide the baseUrl
   baseUrl: http://127.0.0.1:9411/
+  # If using the http collector, milliseconds before timing out when connecting (defaults to null)
+  connectTimout: 10000
+  # If using the http collector, milliseconds before timing out when reading the response (defaults to null)
+  readTimeout: 60000
   # If using the kafka collector, provide the Kafka bootstrap servers
   bootstrapServers: 127.0.0.1:9092;10.0.1.1:9092
 ```

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
@@ -53,27 +53,17 @@ public class HttpZipkinFactory extends AbstractZipkinFactory {
         this.baseUrl = baseUrl;
     }
 
-    private int connectTimeout = 10000;
+    private Integer connectTimeout;
 
     @JsonProperty
-    public int getConnectTimeout() {
-        return connectTimeout;
-    }
-
-    @JsonProperty
-    public void setConnectTimeout(int connectTimeout) {
+    public void setConnectTimeout(Integer connectTimeout) {
         this.connectTimeout = connectTimeout;
     }
 
-    private int readTimeout = 60000;
+    private Integer readTimeout;
 
     @JsonProperty
-    public int getReadTimeout() {
-        return readTimeout;
-    }
-
-    @JsonProperty
-    public void setReadTimeout(int readTimeout) {
+    public void setReadTimeout(Integer readTimeout) {
         this.readTimeout = readTimeout;
     }
 
@@ -94,11 +84,10 @@ public class HttpZipkinFactory extends AbstractZipkinFactory {
         final ReporterMetrics metricsHandler = new DropwizardReporterMetrics(
                 environment.metrics());
 
-        final URLConnectionSender sender = newBuilder()
-            .endpoint(URI.create(baseUrl).resolve("api/v2/spans").toString())
-            .readTimeout(readTimeout)
-            .connectTimeout(connectTimeout)
-            .build();
+        URLConnectionSender.Builder builder = newBuilder().endpoint(URI.create(baseUrl).resolve("api/v2/spans").toString());
+        if (readTimeout != null) builder.readTimeout(readTimeout);
+        if (connectTimeout != null) builder.connectTimeout(connectTimeout);
+        final URLConnectionSender sender = builder.build();
 
         final AsyncReporter<Span> reporter = AsyncReporter.builder(sender)
                 .metrics(metricsHandler).build();

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
@@ -18,6 +18,9 @@ package com.smoketurner.dropwizard.zipkin;
 import java.net.URI;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +56,7 @@ public class HttpZipkinFactory extends AbstractZipkinFactory {
         this.baseUrl = baseUrl;
     }
 
+    @Nullable
     private Integer connectTimeout;
 
     @JsonProperty
@@ -60,6 +64,7 @@ public class HttpZipkinFactory extends AbstractZipkinFactory {
         this.connectTimeout = connectTimeout;
     }
 
+    @Nullable
     private Integer readTimeout;
 
     @JsonProperty

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
@@ -38,7 +38,7 @@ import static zipkin2.reporter.urlconnection.URLConnectionSender.newBuilder;
 public class HttpZipkinFactory extends AbstractZipkinFactory {
 
     private static final Logger LOGGER = LoggerFactory
-        .getLogger(HttpZipkinFactory.class);
+            .getLogger(HttpZipkinFactory.class);
 
     @NotEmpty
     private String baseUrl = "http://127.0.0.1:9411/";
@@ -92,7 +92,7 @@ public class HttpZipkinFactory extends AbstractZipkinFactory {
         }
 
         final ReporterMetrics metricsHandler = new DropwizardReporterMetrics(
-            environment.metrics());
+                environment.metrics());
 
         final URLConnectionSender sender = newBuilder()
             .endpoint(URI.create(baseUrl).resolve("api/v2/spans").toString())
@@ -101,7 +101,7 @@ public class HttpZipkinFactory extends AbstractZipkinFactory {
             .build();
 
         final AsyncReporter<Span> reporter = AsyncReporter.builder(sender)
-            .metrics(metricsHandler).build();
+                .metrics(metricsHandler).build();
 
         environment.lifecycle().manage(new ReporterManager(reporter, sender));
 

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactory.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import io.dropwizard.util.Duration;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,18 +57,18 @@ public class HttpZipkinFactory extends AbstractZipkinFactory {
     }
 
     @Nullable
-    private Integer connectTimeout;
+    private Duration connectTimeout;
 
     @JsonProperty
-    public void setConnectTimeout(Integer connectTimeout) {
+    public void setConnectTimeout(Duration connectTimeout) {
         this.connectTimeout = connectTimeout;
     }
 
     @Nullable
-    private Integer readTimeout;
+    private Duration readTimeout;
 
     @JsonProperty
-    public void setReadTimeout(Integer readTimeout) {
+    public void setReadTimeout(Duration readTimeout) {
         this.readTimeout = readTimeout;
     }
 
@@ -90,8 +90,8 @@ public class HttpZipkinFactory extends AbstractZipkinFactory {
                 environment.metrics());
 
         URLConnectionSender.Builder builder = newBuilder().endpoint(URI.create(baseUrl).resolve("api/v2/spans").toString());
-        if (readTimeout != null) builder.readTimeout(readTimeout);
-        if (connectTimeout != null) builder.connectTimeout(connectTimeout);
+        if (readTimeout != null) builder.readTimeout((int)readTimeout.toMilliseconds());
+        if (connectTimeout != null) builder.connectTimeout((int)connectTimeout.toMilliseconds());
         final URLConnectionSender sender = builder.build();
 
         final AsyncReporter<Span> reporter = AsyncReporter.builder(sender)

--- a/zipkin-example/hello-world.yml
+++ b/zipkin-example/hello-world.yml
@@ -6,6 +6,8 @@ zipkin:
   baseUrl: http://127.0.0.1:9411/
   serviceHost: 127.0.0.1
   servicePort: 8080
+  connectTimeout: 10000
+  readTimeout: 60000
 
 zipkinClient:
   serviceName: hello-world

--- a/zipkin-example/hello-world.yml
+++ b/zipkin-example/hello-world.yml
@@ -6,8 +6,8 @@ zipkin:
   baseUrl: http://127.0.0.1:9411/
   serviceHost: 127.0.0.1
   servicePort: 8080
-  connectTimeout: 10000
-  readTimeout: 60000
+  connectTimeout: 10s
+  readTimeout: 60s
 
 zipkinClient:
   serviceName: hello-world


### PR DESCRIPTION
I would like to externalize the configuration of timeouts. This allows the sender to "fail fast" in case the Zipkin server is hung, which can be useful during startup, in case you don't want to wait the default readTimeout of 60 seconds for the server to come up.