### PR TITLE
Feature/build on run

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,21 @@ Usage
 Add a `ZipkinBundle` to your [Application](https://www.dropwizard.io/1.3.9/dropwizard-core/apidocs/io/dropwizard/Application.html) class.
 
 ```java
-@Override
-public void initialize(Bootstrap<MyConfiguration> bootstrap) {
-    // ...
-    bootstrap.addBundle(new ZipkinBundle<MyConfiguration>(getName()) {
-        @Override
-        public ZipkinFactory getZipkinFactory(MyConfiguration configuration) {
-            return configuration.getZipkinFactory();
-        }
-    });
-}
+private ZipkinBundle<HelloWorldConfiguration> zipkinBundle;
 
 @Override
-public void run(MyConfiguration configuration, Environment environment) throws Exception {
-    Optional<HttpTracing> tracing = configuration.getZipkinFactory().build(environment);
+public void initialize(Bootstrap<HelloWorldConfiguration> bootstrap) {
+  zipkinBundle = new ZipkinBundle<HelloWorldConfiguration>(getName()) {
+    @Override
+    public ZipkinFactory getZipkinFactory(HelloWorldConfiguration configuration) {
+      return configuration.getZipkinFactory();
+    }
+  };
+  bootstrap.addBundle(zipkinBundle);
+}
+@Override
+public void run(HelloWorldConfiguration configuration, Environment environment) throws Exception {
+  final Optional<HttpTracing> tracing = zipkinBundle.getHttpTracing();}
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.zipkin.reporter2</groupId>
+                <artifactId>zipkin-sender-kafka11</artifactId>
+                <version>2.8.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.12.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/zipkin-core/pom.xml
+++ b/zipkin-core/pom.xml
@@ -67,5 +67,11 @@
                 </exclusion>
             </exclusions> -->
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/ZipkinBundle.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/ZipkinBundle.java
@@ -16,16 +16,20 @@
 package com.smoketurner.dropwizard.zipkin;
 
 import com.google.common.base.Strings;
+
+import brave.http.HttpTracing;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.util.Objects;
+import java.util.Optional;
 
 public abstract class ZipkinBundle<C extends Configuration>
     implements ConfiguredBundle<C>, ZipkinConfiguration<C> {
 
   private final String serviceName;
+  private HttpTracing tracing;
 
   /**
    * Constructor
@@ -47,5 +51,10 @@ public abstract class ZipkinBundle<C extends Configuration>
     if (Strings.isNullOrEmpty(braveConfig.getServiceName())) {
       braveConfig.setServiceName(serviceName);
     }
+    tracing = braveConfig.build(environment).orElse(null);
+  }
+
+  public Optional<HttpTracing> getHttpTracing() {
+    return Optional.ofNullable(tracing);
   }
 }

--- a/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/ZipkinBundleTest.java
+++ b/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/ZipkinBundleTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2019 Smoke Turner, LLC (github@smoketurner.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.smoketurner.dropwizard.zipkin;
+
+import brave.http.HttpTracing;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.Optional;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class ZipkinBundleTest {
+  @ClassRule
+  public static DropwizardAppRule<Conf> app =
+      new DropwizardAppRule<>(App.class, ResourceHelpers.resourceFilePath("test.yaml"));
+
+  @Test
+  public void shouldHaveInitializedZipkin() {
+    Assertions.assertThat(getApp().httpTracing).isPresent();
+  }
+
+  private App getApp() {
+    return (App) app.getApplication();
+  }
+
+  public static class App extends Application<Conf> {
+    public ZipkinBundle<Conf> bundle;
+    public Optional<HttpTracing> httpTracing;
+
+    @Override
+    public void initialize(Bootstrap<Conf> bootstrap) {
+      bundle =
+          new ZipkinBundle<Conf>("test") {
+            @Override
+            public ZipkinFactory getZipkinFactory(Conf configuration) {
+              return configuration.zipkin;
+            }
+          };
+      bootstrap.addBundle(bundle);
+    }
+
+    @Override
+    public void run(Conf conf, Environment environment) {
+      httpTracing = bundle.getHttpTracing();
+    }
+  }
+
+  public static class Conf extends Configuration {
+    @Valid @NotNull public final ZipkinFactory zipkin = new ConsoleZipkinFactory();
+  }
+}

--- a/zipkin-core/src/test/resources/test.yaml
+++ b/zipkin-core/src/test/resources/test.yaml
@@ -1,0 +1,10 @@
+zipkin:
+    enabled: true
+
+server:
+    applicationConnectors:
+        - type: http
+          port: 0
+    adminConnectors:
+        - type: http
+          port: 0

--- a/zipkin-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
+++ b/zipkin-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
@@ -30,6 +30,8 @@ import javax.ws.rs.client.Client;
 
 public class HelloWorldApplication extends Application<HelloWorldConfiguration> {
 
+  private ZipkinBundle<HelloWorldConfiguration> zipkinBundle;
+
   public static void main(String[] args) throws Exception {
     new HelloWorldApplication().run(args);
   }
@@ -41,19 +43,20 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
 
   @Override
   public void initialize(Bootstrap<HelloWorldConfiguration> bootstrap) {
-    bootstrap.addBundle(
+    zipkinBundle =
         new ZipkinBundle<HelloWorldConfiguration>(getName()) {
           @Override
           public ZipkinFactory getZipkinFactory(HelloWorldConfiguration configuration) {
             return configuration.getZipkinFactory();
           }
-        });
+        };
+    bootstrap.addBundle(zipkinBundle);
   }
 
   @Override
   public void run(HelloWorldConfiguration configuration, Environment environment) throws Exception {
 
-    final Optional<HttpTracing> tracing = configuration.getZipkinFactory().build(environment);
+    final Optional<HttpTracing> tracing = zipkinBundle.getHttpTracing();
 
     final Client client;
     if (tracing.isPresent()) {


### PR DESCRIPTION
Building the HttpTracing automatically in the `run` method, so that it's available when other bundles' `run` methods are called.

Solves issue #61