### PR TITLE
Updates to Brave 5.12 and off deprecated apis

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -20,7 +20,7 @@ import java.util.Properties;
 
 public class MavenWrapperDownloader {
 
-    private static final String WRAPPER_VERSION = "0.5.5";
+    private static final String WRAPPER_VERSION = "0.5.6";
     /**
      * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
      */

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Maven2 Start Up Batch script
+# Maven Start Up Batch script
 #
 # Required ENV vars:
 # ------------------
@@ -212,9 +212,9 @@ else
       echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
     fi
     if [ -n "$MVNW_REPOURL" ]; then
-      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
+      jarUrl="$MVNW_REPOURL/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
     else
-      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
+      jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
     fi
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
@@ -246,7 +246,7 @@ else
         else
             curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
         fi
-        
+
     else
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Falling back to using Java to download"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -18,7 +18,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Maven2 Start Up Batch script
+@REM Maven Start Up Batch script
 @REM
 @REM Required ENV vars:
 @REM JAVA_HOME - location of a JDK home dir
@@ -26,7 +26,7 @@
 @REM Optional ENV vars
 @REM M2_HOME - location of maven2's installed home dir
 @REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
-@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a key stroke before ending
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
 @REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
 @REM     e.g. to debug Maven itself, use
 @REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
@@ -120,7 +120,7 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
 
 FOR /F "tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
     IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B
@@ -134,7 +134,7 @@ if exist %WRAPPER_JAR% (
     )
 ) else (
     if not "%MVNW_REPOURL%" == "" (
-        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
+        SET DOWNLOAD_URL="%MVNW_REPOURL%/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar"
     )
     if "%MVNW_VERBOSE%" == "true" (
         echo Couldn't find %WRAPPER_JAR%, downloading it ...

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,17 @@
         <tag>HEAD</tag>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>jcenter-snapshots</id>
+            <name>jcenter</name>
+            <url>http://oss.jfrog.org/artifactory/oss-snapshot-local/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/zipkin-core/pom.xml
+++ b/zipkin-core/pom.xml
@@ -44,6 +44,10 @@
         </dependency>
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-reporter-brave</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-sender-urlconnection</artifactId>
         </dependency>
         <dependency>

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/ConsoleZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/ConsoleZipkinFactory.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zipkin2.reporter.Reporter;
+import zipkin2.reporter.brave.ZipkinSpanHandler;
 
 @JsonTypeName("console")
 public class ConsoleZipkinFactory extends AbstractZipkinFactory {
@@ -42,6 +43,6 @@ public class ConsoleZipkinFactory extends AbstractZipkinFactory {
     }
 
     LOGGER.info("Sending spans to console");
-    return buildTracing(environment, Reporter.CONSOLE);
+    return buildTracing(environment, ZipkinSpanHandler.create(Reporter.CONSOLE));
   }
 }

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/EmptyZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/EmptyZipkinFactory.java
@@ -15,13 +15,13 @@
  */
 package com.smoketurner.dropwizard.zipkin;
 
+import brave.handler.SpanHandler;
 import brave.http.HttpTracing;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.setup.Environment;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import zipkin2.reporter.Reporter;
 
 @JsonTypeName("empty")
 public class EmptyZipkinFactory extends AbstractZipkinFactory {
@@ -42,6 +42,6 @@ public class EmptyZipkinFactory extends AbstractZipkinFactory {
     }
 
     LOGGER.info("Dropping all collected spans");
-    return buildTracing(environment, Reporter.NOOP);
+    return buildTracing(environment, SpanHandler.NOOP);
   }
 }

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/ReportingZipkinFactory.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/ReportingZipkinFactory.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.NotNull;
 import zipkin2.Span;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Sender;
+import zipkin2.reporter.brave.ZipkinSpanHandler;
 
 public abstract class ReportingZipkinFactory extends AbstractZipkinFactory {
   @NotNull
@@ -53,6 +54,6 @@ public abstract class ReportingZipkinFactory extends AbstractZipkinFactory {
 
     environment.lifecycle().manage(new ReporterManager(reporter, sender));
 
-    return buildTracing(environment, reporter);
+    return buildTracing(environment, ZipkinSpanHandler.create(reporter));
   }
 }

--- a/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/managed/ReporterManager.java
+++ b/zipkin-core/src/main/java/com/smoketurner/dropwizard/zipkin/managed/ReporterManager.java
@@ -42,7 +42,7 @@ public class ReporterManager implements Managed {
   }
 
   @Override
-  public void start() throws Exception {
+  public void start() {
     final CheckResult result = reporter.check();
     if (!result.ok()) {
       LOGGER.error("Unable to connect to Zipkin destination", result.error());

--- a/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/ConsoleZipkinFactoryTest.java
+++ b/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/ConsoleZipkinFactoryTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class ConsoleZipkinFactoryTest {
 
   @Test
-  public void isDiscoverable() throws Exception {
+  public void isDiscoverable() {
     assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
         .contains(ConsoleZipkinFactory.class);
   }

--- a/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/EmptyZipkinFactoryTest.java
+++ b/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/EmptyZipkinFactoryTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class EmptyZipkinFactoryTest {
 
   @Test
-  public void isDiscoverable() throws Exception {
+  public void isDiscoverable() {
     assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
         .contains(EmptyZipkinFactory.class);
   }

--- a/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactoryTest.java
+++ b/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactoryTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class HttpZipkinFactoryTest {
 
   @Test
-  public void isDiscoverable() throws Exception {
+  public void isDiscoverable() {
     assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
         .contains(HttpZipkinFactory.class);
   }

--- a/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/KafkaZipkinFactoryTest.java
+++ b/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/KafkaZipkinFactoryTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class KafkaZipkinFactoryTest {
 
   @Test
-  public void isDiscoverable() throws Exception {
+  public void isDiscoverable() {
     assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
         .contains(KafkaZipkinFactory.class);
   }

--- a/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/RabbitMQZipkinFactoryTest.java
+++ b/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/RabbitMQZipkinFactoryTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class RabbitMQZipkinFactoryTest {
 
   @Test
-  public void isDiscoverable() throws Exception {
+  public void isDiscoverable() {
     assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
         .contains(RabbitMQZipkinFactory.class);
   }


### PR DESCRIPTION
This prefers `SpanHandler` which allows straight-through serialization, and also other non-zipkin endpoints to work.