### PR TITLE
Polishes Zipkin setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can execute this application by first starting Zipkin on your local machine 
 
 ```
 ./mvnw clean package
-java -jar zipkin-example/target/zipkin-example-2.0.7-2-SNAPSHOT.jar server zipkin-example/hello-world.yml
+java -jar zipkin-example/target/zipkin-example-*-SNAPSHOT.jar server zipkin-example/hello-world.yml
 ```
 
 This will start the application on port `8080` (admin port `8180`). This application demonstrations the following Zipkin integration points:

--- a/zipkin-client/pom.xml
+++ b/zipkin-client/pom.xml
@@ -33,5 +33,9 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-instrumentation-httpclient</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/zipkin-client/src/main/java/com/smoketurner/dropwizard/zipkin/client/ZipkinClientConfiguration.java
+++ b/zipkin-client/src/main/java/com/smoketurner/dropwizard/zipkin/client/ZipkinClientConfiguration.java
@@ -21,15 +21,20 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 public class ZipkinClientConfiguration extends JerseyClientConfiguration {
 
-  @NotEmpty private String serviceName = "";
+  private String serviceName;
 
   @JsonProperty
   public String getServiceName() {
     return serviceName;
   }
 
+  /**
+   * Sets {@code span.remoteServiceName} in spans associated with this client.
+   *
+   * @param serviceName the service name this client will call
+   */
   @JsonProperty
-  public void setServiceName(final String serviceName) {
+  public void setServiceName(@NotEmpty final String serviceName) {
     this.serviceName = serviceName;
   }
 }

--- a/zipkin-example/src/main/java/com/example/helloworld/HelloWorldConfiguration.java
+++ b/zipkin-example/src/main/java/com/example/helloworld/HelloWorldConfiguration.java
@@ -31,7 +31,7 @@ public class HelloWorldConfiguration extends Configuration {
   private final ZipkinClientConfiguration zipkinClient = new ZipkinClientConfiguration();
 
   @JsonProperty
-  public ZipkinFactory getZipkinFactory() {
+  public ZipkinFactory getZipkin() {
     return zipkin;
   }
 


### PR DESCRIPTION
* Uses HttpClient instrumentation (more accurate than JaxRS layer)
* adds supportsJoin (some emulators don't allow it)
* Makes `ZipkinClientBuilder` extend `JerseyClientBuilder` (easier)
* Fixes example application setup (zipkinFactory -> zipkin)