### PR TITLE
Making HttpZipkinFactory respect all parts of BaseUrl and tolerant to trailing slash

### DIFF
--- a/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactoryTest.java
+++ b/zipkin-core/src/test/java/com/smoketurner/dropwizard/zipkin/HttpZipkinFactoryTest.java
@@ -51,4 +51,31 @@ public class HttpZipkinFactoryTest {
     assertThat(httpFactory.getBaseUrl()).isEqualTo("http://example.com:1234/zipkin");
     assertThat(httpFactory.getReportTimeout()).isEqualTo(Duration.days(3));
   }
+
+  @Test
+  public void endpointResolutionShouldCarryFullBaseUrl() {
+    HttpZipkinFactory factory = new HttpZipkinFactory();
+    factory.setBaseUrl("http://example.com:1234/");
+    assertThat(factory.resolveEndpoint()).isEqualTo("http://example.com:1234/api/v2/spans");
+
+    factory = new HttpZipkinFactory();
+    factory.setBaseUrl("http://example.com:1234");
+    assertThat(factory.resolveEndpoint()).isEqualTo("http://example.com:1234/api/v2/spans");
+
+    factory = new HttpZipkinFactory();
+    factory.setBaseUrl("http://example.com:1234/zipkin");
+    assertThat(factory.resolveEndpoint()).isEqualTo("http://example.com:1234/zipkin/api/v2/spans");
+
+    factory = new HttpZipkinFactory();
+    factory.setBaseUrl("http://example.com:1234/zipkin/");
+    assertThat(factory.resolveEndpoint()).isEqualTo("http://example.com:1234/zipkin/api/v2/spans");
+  }
+
+  @Test
+  public void explicitEndpointHasAPirorityOverBaseUrl() {
+    HttpZipkinFactory factory = new HttpZipkinFactory();
+    factory.setBaseUrl("http://example.com:1234/");
+    factory.setEndpoint("http://example.com:1234/spans");
+    assertThat(factory.resolveEndpoint()).isEqualTo("http://example.com:1234/spans");
+  }
 }


### PR DESCRIPTION
1. Now HttpZipkinFactory ignores the relative path of `baseurl`.
So, if http://example.com:1234/zipkin is passed as a `baseurl`, "/zipkin" will be ignored.
This should be fixed, all parts of `baseurl` should be respected.

2. Right now HttpZipkinFactory relies on passed `baseurl` to finish with "/" to construct a valid URL.
For easier usage of the dropwizard-zipkin library, HttpZipkinFactory should be tolerant of the absence of trailing slash in `baseurl`.